### PR TITLE
[fix] ManagerOptions.user was undefined unless manually passed by dev

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,9 +5,7 @@ export * from "lavacord";
 
 export class Manager extends LavacordManager {
     public constructor(readonly client: DiscordClient, nodes: LavalinkNodeOptions[], options?: ManagerOptions) {
-        if (options && !options.user && client.user?.id) options.user = client.user.id;
-        else if (!options && client.user?.id) options = { user: client.user.id };
-        super(nodes, options || {});
+        super(nodes, options && !options.user && client.user?.id ? Object.assign(options, { user: client.user.id }) : { user: client.user?.id });
 
         this.send = packet => {
             if (this.client.guilds.cache) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ export * from "lavacord";
 
 export class Manager extends LavacordManager {
     public constructor(readonly client: DiscordClient, nodes: LavalinkNodeOptions[], options?: ManagerOptions) {
+        if (options && !options.user && client.user?.id) options.user = client.user.id;
+        else if (!options && client.user?.id) options = { user: client.user.id };
         super(nodes, options || {});
 
         this.send = packet => {


### PR DESCRIPTION
This kind of behavior didn't really make sense considering the Manager most likely has access to the client's user ID if it's already entered the ready state. If it hasn't then the dev still has to pass ManagerOptions.user. This just makes it so that the Constructor param options can truly be optional.